### PR TITLE
Use the actual param rather than the Sinatra::Params object

### DIFF
--- a/exe/faastruby-server
+++ b/exe/faastruby-server
@@ -137,7 +137,7 @@ class FaaStRubyServer < Sinatra::Application
   def parse_query(query_string)
     hash = {}
     query_string.split('&').each do |param|
-      key, value = params.split('=')
+      key, value = param.split('=')
       hash[key] = value
     end
     hash


### PR DESCRIPTION
When trying to use event.query_params locally it was actually using the Sinatra::Params object due to a typo