### PR TITLE
Read all of stdin when updating context from stdin

### DIFF
--- a/lib/faastruby/cli/commands/function/update_context.rb
+++ b/lib/faastruby/cli/commands/function/update_context.rb
@@ -52,7 +52,7 @@ module FaaStRuby
             when '-d', '--data'
               @options['data'] = @args.shift
             when '--stdin'
-              @options['data'] = STDIN.gets.chomp
+              @options['data'] = STDIN.read
             else
               FaaStRuby::CLI.error("Unknown argument: #{option}")
             end


### PR DESCRIPTION
When running `faastruby update-context` with `--stdin`, it should read all of stdin, not just the first line. This matches standard expected Linux command line tool behavior, so you can pipe in full files, etc.

The current behavior really confused me for a while.