### PR TITLE
Add 2.6.2 as supported Ruby version

### DIFF
--- a/lib/faastruby/supported_runtimes.rb
+++ b/lib/faastruby/supported_runtimes.rb
@@ -1,6 +1,6 @@
 module FaaStRuby
   # It is important that they are sorted in version order!
-  SUPPORTED_RUBY = ['2.5.3', '2.6.0', '2.6.1']
+  SUPPORTED_RUBY = ['2.5.3', '2.6.0', '2.6.1', '2.6.2']
   SUPPORTED_CRYSTAL = ['0.27.0', '0.27.2']
   CRYSTAL_LATEST = SUPPORTED_CRYSTAL.last
   RUBY_LATEST = SUPPORTED_RUBY.last


### PR DESCRIPTION
Ruby 2.6.2 was released on March 13th but isn't yet supported by FaaStRuby:

```
Unsupported Ruby version: 2.6.2
```

This PR fixes that.